### PR TITLE
Add Swift Vectors

### DIFF
--- a/ColorWheel.xcodeproj/project.pbxproj
+++ b/ColorWheel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9B2709A82BC4A0EB0002C574 /* Vectors in Frameworks */ = {isa = PBXBuildFile; productRef = 9B2709A72BC4A0EB0002C574 /* Vectors */; };
 		9B2E405C2B9BAD7C00FB19C1 /* CGPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E405B2B9BAD7C00FB19C1 /* CGPoint+Extensions.swift */; };
 		9B2E40602B9BB02000FB19C1 /* ControlPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E405F2B9BB02000FB19C1 /* ControlPoint.swift */; };
 		9B2E40632B9BB22F00FB19C1 /* CGRect+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E40622B9BB22F00FB19C1 /* CGRect+Extension.swift */; };
@@ -48,6 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B2709A82BC4A0EB0002C574 /* Vectors in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,6 +150,9 @@
 			dependencies = (
 			);
 			name = ColorWheel;
+			packageProductDependencies = (
+				9B2709A72BC4A0EB0002C574 /* Vectors */,
+			);
 			productName = ColorWheel;
 			productReference = 9BC482942B9A6FEF00F5A777 /* ColorWheel.app */;
 			productType = "com.apple.product-type.application";
@@ -176,6 +181,9 @@
 				Base,
 			);
 			mainGroup = 9BC4828B2B9A6FEF00F5A777;
+			packageReferences = (
+				9B2709A62BC4A0EB0002C574 /* XCRemoteSwiftPackageReference "swift-vectors" */,
+			);
 			productRefGroup = 9BC482952B9A6FEF00F5A777 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -420,6 +428,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9B2709A62BC4A0EB0002C574 /* XCRemoteSwiftPackageReference "swift-vectors" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gaetanomatonti/swift-vectors";
+			requirement = {
+				branch = "feature/add-vector";
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9B2709A72BC4A0EB0002C574 /* Vectors */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B2709A62BC4A0EB0002C574 /* XCRemoteSwiftPackageReference "swift-vectors" */;
+			productName = Vectors;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9BC4828C2B9A6FEF00F5A777 /* Project object */;
 }

--- a/ColorWheel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ColorWheel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "401db2451f59777aeb1f617b9a31716848f38c69b14026149a71ae0a9e8678e3",
+  "pins" : [
+    {
+      "identity" : "swift-vectors",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gaetanomatonti/swift-vectors",
+      "state" : {
+        "branch" : "feature/add-vector",
+        "revision" : "d8a31d9c898b2056e07fd95f39541054ac22e437"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ColorWheel/Extensions/CGPoint+Extensions.swift
+++ b/ColorWheel/Extensions/CGPoint+Extensions.swift
@@ -7,65 +7,11 @@
 
 import Foundation
 import SwiftUI
-
-// MARK: - Operators
-
-extension CGPoint {
-  /// Adds a vector to this vector.
-  /// - Returns: The vector resulting from the sum of the vectors.
-  static func +(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
-    CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
-  }
-
-  /// Subtracts a vector to this vector.
-  /// - Returns: The vector resulting from the subtraction of the vectors.
-  static func -(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
-    CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
-  }
-
-  /// Multiplies (or scales) the vector by a scalar.
-  /// - Returns: The scaled vector.
-  static func *(lhs: CGPoint, n: CGFloat) -> CGPoint {
-    CGPoint(x: lhs.x * n, y: lhs.y * n)
-  }
-
-  /// Divides (or scales) the vector by a scalar.
-  /// - Returns: The scaled vector.
-  static func /(lhs: CGPoint, n: CGFloat) -> CGPoint {
-    CGPoint(x: lhs.x / n, y: lhs.y / n)
-  }
-}
+import Vectors
 
 // MARK: - Helpers
 
 extension CGPoint {
-  /// Returns a vector normalized to a unit length of 1.
-  var normalized: CGPoint {
-    let magnitude = self.magnitude
-
-    guard magnitude > .zero else {
-      return self
-    }
-
-    return self / magnitude
-  }
-
-  /// Returns the magnitude (or length) of the vector.
-  var magnitude: CGFloat {
-    sqrt(x * x + y * y)
-  }
-
-  /// Limits the magnitude of the vector.
-  /// - Parameter maximum: The maximum magnitude of the vector.
-  /// - Returns: A limited vector.
-  func limit(_ maximum: CGFloat) -> CGPoint {
-    guard magnitude > maximum else {
-      return self
-    }
-
-    return normalized * maximum
-  }
-  
   /// Computes the cartesian-coordinates from polar-coordinates.
   /// - Parameters:
   ///   - angle: The angle of the coordinates.

--- a/ColorWheel/Extensions/Color+Extensions.swift
+++ b/ColorWheel/Extensions/Color+Extensions.swift
@@ -11,7 +11,7 @@ import SwiftUI
 extension Color {
   /// Creates a constant color from hue, saturation, and brightness values.
   /// - Parameters:
-  ///   - hue: The angle value of the hue.
+  ///   - hue: The angle value of the hue. Remapped to always be in the range `[0, 2π]`.
   ///   - saturation: The saturation of the color in the range `0` to `1`.
   ///   - brightness: The brightness of the color in the range `0` to `1`.
   init(hue: Angle, saturation: Double, brightness: Double, opacity: Double = 1.0) {

--- a/ColorWheel/Shaders/ColorWheel.metal
+++ b/ColorWheel/Shaders/ColorWheel.metal
@@ -8,7 +8,7 @@
 #include <metal_stdlib>
 using namespace metal;
 
-#define TWO_PI (M_PI_H * 2)
+#define M_TWO_PI_H (M_PI_H * 2)
 
 half3 mod(half3 x, half3 y) {
   return x - y * floor(x / y);

--- a/ColorWheel/UI/ControlPoint.swift
+++ b/ColorWheel/UI/ControlPoint.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import Vectors
 
 /// A view that displays a draggable control point that controls color selection.
 struct ControlPoint: View {

--- a/ColorWheel/UI/ControlPoint.swift
+++ b/ColorWheel/UI/ControlPoint.swift
@@ -40,7 +40,7 @@ struct ControlPoint: View {
 
   /// The vector of the control point that points to the center of the circle.
   private var toCenter: CGPoint {
-    center - position
+    position - center
   }
 
   /// The currently selected color.
@@ -89,7 +89,7 @@ struct ControlPoint: View {
   /// Updates the hue of the color from the angle of the control point.
   private func updateHue() {
     let normalizedToCenter = toCenter.normalized
-    let angle = atan2(normalizedToCenter.y, normalizedToCenter.x) + .pi
+    let angle = atan2(normalizedToCenter.y, normalizedToCenter.x)
     hue = .radians(angle)
   }
 

--- a/ColorWheel/UI/ControlPoint.swift
+++ b/ColorWheel/UI/ControlPoint.swift
@@ -88,9 +88,7 @@ struct ControlPoint: View {
 
   /// Updates the hue of the color from the angle of the control point.
   private func updateHue() {
-    let normalizedToCenter = toCenter.normalized
-    let angle = atan2(normalizedToCenter.y, normalizedToCenter.x)
-    hue = .radians(angle)
+    hue = toCenter.normalized.heading
   }
 
   /// Updates the saturation of the color from the distance of the control point to the center.


### PR DESCRIPTION
### Description
This PR adds the dependency to the [swift-vectors](https://github.com/gaetanomatonti/swift-vectors) package.

### Changes
- Fixed a missing macro definition in the color wheel shader, preventing it from compiling.
- Added the dependency to the [swift-vectors](https://github.com/gaetanomatonti/swift-vectors) package and removed the `CGPoint` extension.
- Fixed the direction of the vector pointing from the center of the wheel to the control point. This required rescaling the vector's heading by adding `π`.
- Improve color helper documentation.
- Improve the computation of the hue angle from the position of the control point.