### PR TITLE
Add Sliders

### DIFF
--- a/ColorWheel.xcodeproj/project.pbxproj
+++ b/ColorWheel.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		9B6D60572B9C7516004D511D /* Angle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D60562B9C7516004D511D /* Angle+Extensions.swift */; };
 		9B6D60592B9C761A004D511D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D60582B9C761A004D511D /* ContentView.swift */; };
 		9B6D605D2B9C76CA004D511D /* GradientPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D605C2B9C76CA004D511D /* GradientPalette.swift */; };
+		9B7149782BC9E3C6006F9BAD /* PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7149772BC9E3C6006F9BAD /* PercentageConvertible.swift */; };
+		9B71497A2BC9E466006F9BAD /* BinaryFloatingPoint+PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7149792BC9E466006F9BAD /* BinaryFloatingPoint+PercentageConvertible.swift */; };
+		9B71497C2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B71497B2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift */; };
+		9B71497E2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */; };
+		9B7149812BC9E656006F9BAD /* ColorSlider+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */; };
 		9BC482982B9A6FEF00F5A777 /* ColorWheelApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC482972B9A6FEF00F5A777 /* ColorWheelApp.swift */; };
 		9BC4829A2B9A6FEF00F5A777 /* ColorWheel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */; };
 		9BC4829C2B9A6FF000F5A777 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9BC4829B2B9A6FF000F5A777 /* Assets.xcassets */; };
@@ -36,6 +41,11 @@
 		9B6D60562B9C7516004D511D /* Angle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Angle+Extensions.swift"; sourceTree = "<group>"; };
 		9B6D60582B9C761A004D511D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		9B6D605C2B9C76CA004D511D /* GradientPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientPalette.swift; sourceTree = "<group>"; };
+		9B7149772BC9E3C6006F9BAD /* PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PercentageConvertible.swift; sourceTree = "<group>"; };
+		9B7149792BC9E466006F9BAD /* BinaryFloatingPoint+PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BinaryFloatingPoint+PercentageConvertible.swift"; sourceTree = "<group>"; };
+		9B71497B2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Angle+PercentageConvertible.swift"; sourceTree = "<group>"; };
+		9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClosedRange+PercentageConvertible.swift"; sourceTree = "<group>"; };
+		9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorSlider+Style.swift"; sourceTree = "<group>"; };
 		9BC482942B9A6FEF00F5A777 /* ColorWheel.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ColorWheel.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BC482972B9A6FEF00F5A777 /* ColorWheelApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorWheelApp.swift; sourceTree = "<group>"; };
 		9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorWheel.swift; sourceTree = "<group>"; };
@@ -67,12 +77,12 @@
 		9B2E405E2B9BB00F00FB19C1 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				9B71497F2BC9E645006F9BAD /* ColorSlider */,
 				9B6D60582B9C761A004D511D /* ContentView.swift */,
 				9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */,
 				9B2E405F2B9BB02000FB19C1 /* ControlPoint.swift */,
 				9B2E406E2B9BE4F300FB19C1 /* ColorPoint.swift */,
 				9B6D605C2B9C76CA004D511D /* GradientPalette.swift */,
-				9B479CEA2BC818820029BA60 /* ColorSlider.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -83,6 +93,9 @@
 				9B2E40622B9BB22F00FB19C1 /* CGRect+Extension.swift */,
 				9B2E406C2B9BE35B00FB19C1 /* Color+Extensions.swift */,
 				9B6D60562B9C7516004D511D /* Angle+Extensions.swift */,
+				9B7149792BC9E466006F9BAD /* BinaryFloatingPoint+PercentageConvertible.swift */,
+				9B71497B2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift */,
+				9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -92,8 +105,18 @@
 			children = (
 				9B2E40642B9BCA2400FB19C1 /* Scheme.swift */,
 				9B2E40672B9BD87300FB19C1 /* HSB.swift */,
+				9B7149772BC9E3C6006F9BAD /* PercentageConvertible.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		9B71497F2BC9E645006F9BAD /* ColorSlider */ = {
+			isa = PBXGroup;
+			children = (
+				9B479CEA2BC818820029BA60 /* ColorSlider.swift */,
+				9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */,
+			);
+			path = ColorSlider;
 			sourceTree = "<group>";
 		};
 		9BC4828B2B9A6FEF00F5A777 = {
@@ -213,15 +236,20 @@
 				9B479CEB2BC818820029BA60 /* ColorSlider.swift in Sources */,
 				9B2E40602B9BB02000FB19C1 /* ControlPoint.swift in Sources */,
 				9B6D60572B9C7516004D511D /* Angle+Extensions.swift in Sources */,
+				9B7149812BC9E656006F9BAD /* ColorSlider+Style.swift in Sources */,
+				9B71497E2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift in Sources */,
 				9B2E40682B9BD87300FB19C1 /* HSB.swift in Sources */,
 				9B6D605D2B9C76CA004D511D /* GradientPalette.swift in Sources */,
 				9B2E406D2B9BE35B00FB19C1 /* Color+Extensions.swift in Sources */,
 				9BC482A62B9A700200F5A777 /* ColorWheel.metal in Sources */,
+				9B71497A2BC9E466006F9BAD /* BinaryFloatingPoint+PercentageConvertible.swift in Sources */,
 				9BC4829A2B9A6FEF00F5A777 /* ColorWheel.swift in Sources */,
 				9B2E40632B9BB22F00FB19C1 /* CGRect+Extension.swift in Sources */,
 				9B2E406F2B9BE4F300FB19C1 /* ColorPoint.swift in Sources */,
+				9B71497C2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift in Sources */,
 				9B6D60592B9C761A004D511D /* ContentView.swift in Sources */,
 				9B2E40652B9BCA2400FB19C1 /* Scheme.swift in Sources */,
+				9B7149782BC9E3C6006F9BAD /* PercentageConvertible.swift in Sources */,
 				9BC482982B9A6FEF00F5A777 /* ColorWheelApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ColorWheel.xcodeproj/project.pbxproj
+++ b/ColorWheel.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9B71497C2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B71497B2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift */; };
 		9B71497E2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */; };
 		9B7149812BC9E656006F9BAD /* ColorSlider+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */; };
+		9B78F2822BC9E80900B0275D /* ColorSlider+Grabber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78F2812BC9E80900B0275D /* ColorSlider+Grabber.swift */; };
 		9BC482982B9A6FEF00F5A777 /* ColorWheelApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC482972B9A6FEF00F5A777 /* ColorWheelApp.swift */; };
 		9BC4829A2B9A6FEF00F5A777 /* ColorWheel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */; };
 		9BC4829C2B9A6FF000F5A777 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9BC4829B2B9A6FF000F5A777 /* Assets.xcassets */; };
@@ -46,6 +47,7 @@
 		9B71497B2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Angle+PercentageConvertible.swift"; sourceTree = "<group>"; };
 		9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClosedRange+PercentageConvertible.swift"; sourceTree = "<group>"; };
 		9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorSlider+Style.swift"; sourceTree = "<group>"; };
+		9B78F2812BC9E80900B0275D /* ColorSlider+Grabber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorSlider+Grabber.swift"; sourceTree = "<group>"; };
 		9BC482942B9A6FEF00F5A777 /* ColorWheel.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ColorWheel.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BC482972B9A6FEF00F5A777 /* ColorWheelApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorWheelApp.swift; sourceTree = "<group>"; };
 		9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorWheel.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				9B479CEA2BC818820029BA60 /* ColorSlider.swift */,
+				9B78F2812BC9E80900B0275D /* ColorSlider+Grabber.swift */,
 				9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */,
 			);
 			path = ColorSlider;
@@ -235,6 +238,7 @@
 			files = (
 				9B479CEB2BC818820029BA60 /* ColorSlider.swift in Sources */,
 				9B2E40602B9BB02000FB19C1 /* ControlPoint.swift in Sources */,
+				9B78F2822BC9E80900B0275D /* ColorSlider+Grabber.swift in Sources */,
 				9B6D60572B9C7516004D511D /* Angle+Extensions.swift in Sources */,
 				9B7149812BC9E656006F9BAD /* ColorSlider+Style.swift in Sources */,
 				9B71497E2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift in Sources */,

--- a/ColorWheel.xcodeproj/project.pbxproj
+++ b/ColorWheel.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		9B71497E2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */; };
 		9B7149812BC9E656006F9BAD /* ColorSlider+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */; };
 		9B78F2822BC9E80900B0275D /* ColorSlider+Grabber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78F2812BC9E80900B0275D /* ColorSlider+Grabber.swift */; };
+		9B78F2842BC9F07F00B0275D /* ColorSlider+Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B78F2832BC9F07F00B0275D /* ColorSlider+Track.swift */; };
 		9BC482982B9A6FEF00F5A777 /* ColorWheelApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC482972B9A6FEF00F5A777 /* ColorWheelApp.swift */; };
 		9BC4829A2B9A6FEF00F5A777 /* ColorWheel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */; };
 		9BC4829C2B9A6FF000F5A777 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9BC4829B2B9A6FF000F5A777 /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		9B71497D2BC9E5D3006F9BAD /* ClosedRange+PercentageConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClosedRange+PercentageConvertible.swift"; sourceTree = "<group>"; };
 		9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorSlider+Style.swift"; sourceTree = "<group>"; };
 		9B78F2812BC9E80900B0275D /* ColorSlider+Grabber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorSlider+Grabber.swift"; sourceTree = "<group>"; };
+		9B78F2832BC9F07F00B0275D /* ColorSlider+Track.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorSlider+Track.swift"; sourceTree = "<group>"; };
 		9BC482942B9A6FEF00F5A777 /* ColorWheel.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ColorWheel.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BC482972B9A6FEF00F5A777 /* ColorWheelApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorWheelApp.swift; sourceTree = "<group>"; };
 		9BC482992B9A6FEF00F5A777 /* ColorWheel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorWheel.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				9B479CEA2BC818820029BA60 /* ColorSlider.swift */,
 				9B78F2812BC9E80900B0275D /* ColorSlider+Grabber.swift */,
 				9B7149802BC9E656006F9BAD /* ColorSlider+Style.swift */,
+				9B78F2832BC9F07F00B0275D /* ColorSlider+Track.swift */,
 			);
 			path = ColorSlider;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 				9B2E406F2B9BE4F300FB19C1 /* ColorPoint.swift in Sources */,
 				9B71497C2BC9E54F006F9BAD /* Angle+PercentageConvertible.swift in Sources */,
 				9B6D60592B9C761A004D511D /* ContentView.swift in Sources */,
+				9B78F2842BC9F07F00B0275D /* ColorSlider+Track.swift in Sources */,
 				9B2E40652B9BCA2400FB19C1 /* Scheme.swift in Sources */,
 				9B7149782BC9E3C6006F9BAD /* PercentageConvertible.swift in Sources */,
 				9BC482982B9A6FEF00F5A777 /* ColorWheelApp.swift in Sources */,

--- a/ColorWheel.xcodeproj/project.pbxproj
+++ b/ColorWheel.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		9B2E40682B9BD87300FB19C1 /* HSB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E40672B9BD87300FB19C1 /* HSB.swift */; };
 		9B2E406D2B9BE35B00FB19C1 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E406C2B9BE35B00FB19C1 /* Color+Extensions.swift */; };
 		9B2E406F2B9BE4F300FB19C1 /* ColorPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2E406E2B9BE4F300FB19C1 /* ColorPoint.swift */; };
+		9B479CEB2BC818820029BA60 /* ColorSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B479CEA2BC818820029BA60 /* ColorSlider.swift */; };
 		9B6D60572B9C7516004D511D /* Angle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D60562B9C7516004D511D /* Angle+Extensions.swift */; };
 		9B6D60592B9C761A004D511D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D60582B9C761A004D511D /* ContentView.swift */; };
 		9B6D605D2B9C76CA004D511D /* GradientPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D605C2B9C76CA004D511D /* GradientPalette.swift */; };
@@ -31,6 +32,7 @@
 		9B2E40672B9BD87300FB19C1 /* HSB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HSB.swift; sourceTree = "<group>"; };
 		9B2E406C2B9BE35B00FB19C1 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		9B2E406E2B9BE4F300FB19C1 /* ColorPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPoint.swift; sourceTree = "<group>"; };
+		9B479CEA2BC818820029BA60 /* ColorSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSlider.swift; sourceTree = "<group>"; };
 		9B6D60562B9C7516004D511D /* Angle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Angle+Extensions.swift"; sourceTree = "<group>"; };
 		9B6D60582B9C761A004D511D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		9B6D605C2B9C76CA004D511D /* GradientPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientPalette.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				9B2E405F2B9BB02000FB19C1 /* ControlPoint.swift */,
 				9B2E406E2B9BE4F300FB19C1 /* ColorPoint.swift */,
 				9B6D605C2B9C76CA004D511D /* GradientPalette.swift */,
+				9B479CEA2BC818820029BA60 /* ColorSlider.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -207,6 +210,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B479CEB2BC818820029BA60 /* ColorSlider.swift in Sources */,
 				9B2E40602B9BB02000FB19C1 /* ControlPoint.swift in Sources */,
 				9B6D60572B9C7516004D511D /* Angle+Extensions.swift in Sources */,
 				9B2E40682B9BD87300FB19C1 /* HSB.swift in Sources */,

--- a/ColorWheel/Extensions/Angle+Extensions.swift
+++ b/ColorWheel/Extensions/Angle+Extensions.swift
@@ -11,10 +11,15 @@ import SwiftUI
 extension Angle {
   /// Creates a new instance of the angle with an absolute (positive) value.
   var absolute: Angle {
-    if radians < .zero {
-      return Angle(radians: radians + .pi * 2)
-    }
+    get {
+      if radians < .zero {
+        return Angle(radians: radians + .pi * 2)
+      }
 
-    return self
+      return self
+    }
+    set {
+      self = newValue.absolute
+    }
   }
 }

--- a/ColorWheel/Extensions/Angle+Extensions.swift
+++ b/ColorWheel/Extensions/Angle+Extensions.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 extension Angle {
-  /// Creates a new instance of the angle with an absolute (positive) value.
+  /// The angle with an absolute value.
   var absolute: Angle {
     get {
       if radians < .zero {

--- a/ColorWheel/Extensions/Angle+PercentageConvertible.swift
+++ b/ColorWheel/Extensions/Angle+PercentageConvertible.swift
@@ -1,0 +1,23 @@
+//
+//  PercentageConvertible+Angle.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 12/04/24.
+//
+
+import Foundation
+import SwiftUI
+
+extension Angle: PercentageConvertible {
+  func percentage(in range: ClosedRange<Angle>) -> Double {
+    let value = self.degrees - range.lowerBound.degrees
+    let total = range.upperBound.degrees - range.lowerBound.degrees
+    return Double(value / total)
+  }
+
+  static func value(from percentage: Double, in range: ClosedRange<Angle>) -> Angle {
+    let value = percentage * range.upperBound.degrees
+    let clampedValue = max(range.lowerBound.degrees, min(value, range.upperBound.degrees))
+    return .degrees(clampedValue)
+  }
+}

--- a/ColorWheel/Extensions/BinaryFloatingPoint+PercentageConvertible.swift
+++ b/ColorWheel/Extensions/BinaryFloatingPoint+PercentageConvertible.swift
@@ -1,0 +1,27 @@
+//
+//  PercentageConvertible+BinaryFloatingPoint.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 12/04/24.
+//
+
+import Foundation
+
+extension PercentageConvertible where Self: BinaryFloatingPoint {
+  func percentage(in range: ClosedRange<Self>) -> Double {
+    let value = self - range.lowerBound
+    let total = range.upperBound - range.lowerBound
+    return Double(value / total)
+  }
+
+  static func value(from percentage: Double, in range: ClosedRange<Self>) -> Self {
+    let value = Self(percentage) * range.upperBound
+    return max(range.lowerBound, min(value, range.upperBound))
+  }
+}
+
+extension Float: PercentageConvertible {}
+
+extension Double: PercentageConvertible {}
+
+extension CGFloat: PercentageConvertible {}

--- a/ColorWheel/Extensions/ClosedRange+PercentageConvertible.swift
+++ b/ColorWheel/Extensions/ClosedRange+PercentageConvertible.swift
@@ -1,0 +1,17 @@
+//
+//  ClosedRange+PercentageConvertible.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 12/04/24.
+//
+
+import Foundation
+
+extension ClosedRange where Bound: PercentageConvertible {
+  /// Computes the value represented by the passed percentage.
+  /// - Parameter percentage: The percentage of the value.
+  /// - Returns: The value corresponding to the percentage in the range.
+  func value(from percentage: Double) -> Bound {
+    Bound.value(from: percentage, in: self)
+  }
+}

--- a/ColorWheel/Models/HSB.swift
+++ b/ColorWheel/Models/HSB.swift
@@ -37,6 +37,6 @@ struct HSB: Hashable, Identifiable {
 
   /// The `Color` represented in HSB values.
   var color: Color {
-    Color(hue: hue, saturation: saturation, brightness: 1)
+    Color(hue: hue, saturation: saturation, brightness: brightness)
   }
 }

--- a/ColorWheel/Models/PercentageConvertible.swift
+++ b/ColorWheel/Models/PercentageConvertible.swift
@@ -1,0 +1,23 @@
+//
+//  PercentageConvertible.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 12/04/24.
+//
+
+import Foundation
+
+/// A protocol defining requirements for a type that can be converted to a percentage value and vice versa.
+protocol PercentageConvertible: Comparable {
+  /// Computes the percentage of the value in the passed range.
+  /// - Parameter range: The range of possible values.
+  /// - Returns: A clamped `Double` value representing the percentage in the range `[0, 1]`.
+  func percentage(in range: ClosedRange<Self>) -> Double
+
+  /// Computes the value from the percentage in the passed range.
+  /// - Parameters:
+  ///   - percentage: The percentage of the value.
+  ///   - range: The range of possible values.
+  /// - Returns: A value corresponding to the percentage in the specified range.
+  static func value(from percentage: Double, in range: ClosedRange<Self>) -> Self
+}

--- a/ColorWheel/Models/Scheme.swift
+++ b/ColorWheel/Models/Scheme.swift
@@ -100,9 +100,9 @@ extension Scheme {
   ///   - hue: The hue of the starting color.
   ///   - saturation: The saturation of the starting color.
   /// - Returns: The array of `HSB` colors in the harmony scheme.
-  func colors(from hue: Angle, saturation: CGFloat) -> [HSB] {
+  func colors(from hue: Angle, saturation: CGFloat, brightness: CGFloat) -> [HSB] {
     shiftAngles.enumerated().map { index, angle in
-      HSB(id: index + 1, hue: hue + angle, saturation: saturation, brightness: 1)
+      HSB(id: index + 1, hue: hue + angle, saturation: saturation, brightness: brightness)
     }
   }
 }

--- a/ColorWheel/Shaders/ColorWheel.metal
+++ b/ColorWheel/Shaders/ColorWheel.metal
@@ -25,7 +25,7 @@ half3 hsb2rgb(half3 color) {
   return brightness * mix(half3(1.0), rgb, saturation);
 }
 
-[[ stitchable ]] half4 colorWheel(float2 position, float4 bounds) {
+[[ stitchable ]] half4 colorWheel(float2 position, float4 bounds, float brightness) {
   float2 st = position / bounds.zw;
   float2 center = st - float2(0.5);
   float angle = atan2(center.y, center.x);
@@ -33,9 +33,16 @@ half3 hsb2rgb(half3 color) {
 
   float hue = angle / M_TWO_PI_H;
   float saturation = radius;
-  float brightness = 1.0;
 
   half3 rgb = hsb2rgb(half3(hue, saturation, brightness));
+
+  return half4(rgb, 1.0);
+}
+
+[[ stitchable ]] half4 hue(float2 position, float4 bounds) {
+  float hue = position.x / bounds.z;
+
+  half3 rgb = hsb2rgb(half3(hue, 1, 1));
 
   return half4(rgb, 1.0);
 }

--- a/ColorWheel/UI/ColorSlider.swift
+++ b/ColorWheel/UI/ColorSlider.swift
@@ -1,0 +1,141 @@
+//
+//  ColorSlider.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 11/04/24.
+//
+
+import SwiftUI
+import Vectors
+
+struct ColorSlider<Value>: View where Value == Double {
+  private let height: CGFloat = 48
+    
+  /// The value of the slider.
+  @Binding var value: Value
+  
+  /// The position of the grabber.
+  @State private var position: CGPoint = .zero
+  
+  @Environment(\.backgroundStyle) var backgroundStyle
+    
+  private var shape: some Shape {
+    RoundedRectangle(cornerRadius: 24, style: .continuous)
+  }
+  
+  private var grabberRadius: CGFloat {
+    height / 2
+  }
+  
+  private var minimum: Value {
+    range.lowerBound
+  }
+  
+  private var maximum: Value {
+    range.upperBound
+  }
+  
+  private var percentage: CGFloat {
+    value / range.upperBound
+  }
+  
+  let range: ClosedRange<Value>
+  
+  init(value: Binding<Value>, range: ClosedRange<Value> = 0...1) {
+    self._value = value
+    self.range = range
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      ZStack {
+        shape
+          .fill(backgroundStyle ?? AnyShapeStyle(.background))
+          .stroke(.thinMaterial, lineWidth: 2)
+          .frame(width: geometry.size.width)
+        
+        Grabber()
+          .position(position)
+          .gesture(
+            DragGesture()
+              .onChanged { gesture in
+                updateValue(for: gesture.location, in: geometry.frame(in: .local))
+              }
+          )
+          .onChange(of: value) { oldValue, newValue in
+            position = grabberPosition(in: geometry.frame(in: .local))
+          }
+          .onAppear {
+            position = grabberPosition(in: geometry.frame(in: .local))
+          }
+      }
+    }
+    .frame(height: 48)
+  }
+  
+  func updateValue(for location: CGPoint, in rect: CGRect) {
+    value = max(0, min(location.x / railsRect(in: rect).width, 1))
+  }
+  
+  func railsRect(in rect: CGRect) -> CGRect {
+    rect.insetBy(dx: grabberRadius, dy: .zero)
+  }
+  
+  func grabberPosition(in rect: CGRect) -> CGPoint {
+    let railsRect = railsRect(in: rect)
+    
+    return CGPoint(
+      x: railsRect.minX + railsRect.width * percentage,
+      y: rect.midY
+    )
+  }
+}
+
+extension ColorSlider {
+  struct Grabber: View {
+    @Environment(\.colorSliderGrabberStyle) var grabberStyle
+
+    var body: some View {
+      Circle()
+        .fill(grabberStyle)
+        .stroke(.thinMaterial, lineWidth: 4)
+    }
+  }
+}
+
+enum ColorSliderGrabberStyle: EnvironmentKey {
+  static var defaultValue: AnyShapeStyle = AnyShapeStyle(Color.blue)
+}
+
+extension EnvironmentValues {
+  var colorSliderGrabberStyle: AnyShapeStyle {
+    get {
+      self[ColorSliderGrabberStyle.self]
+    }
+    set {
+      self[ColorSliderGrabberStyle.self] = newValue
+    }
+  }
+}
+
+extension View {
+  func colorSliderGrabberStyle(_ style: some ShapeStyle) -> some View {
+    environment(\.colorSliderGrabberStyle, AnyShapeStyle(style))
+  }
+}
+
+#if DEBUG
+#Preview {
+  struct Wrapped: View {
+    @State private var progress: Double = .zero
+    
+    var body: some View {
+      ColorSlider(value: $progress)
+        .padding()
+    }
+  }
+  
+  return Wrapped()
+    .backgroundStyle(ShaderLibrary.hue(.boundingRect))
+}
+#endif

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Grabber.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Grabber.swift
@@ -28,7 +28,7 @@ extension ColorSlider {
     /// The value of the slider.
     @Binding var value: Value
 
-    @Environment(\.colorSliderGrabberStyle) var grabberStyle
+    @Environment(\.colorSliderGrabberStyle) var style
 
     /// The percentage of the value in the range.
     private var percentage: CGFloat {
@@ -51,7 +51,7 @@ extension ColorSlider {
 
     var body: some View {
       Circle()
-        .fill(grabberStyle)
+        .fill(style)
         .stroke(.thinMaterial, lineWidth: 4)
         .position(position)
         .gesture(

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Grabber.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Grabber.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import Vectors
 
 extension ColorSlider {
   /// A view that displays the component the user grabs to pick values in the slider.
@@ -70,7 +71,7 @@ extension ColorSlider {
     /// Updates the selected value from the coordinates of the grabber.
     /// - Parameter location: The location of the drag gesture used to position the grabber.
     func updateValue(for location: CGPoint) {
-      let percentage = location.x / frame.width
+      let percentage = (location.x - frame.minX) / frame.width
       value = range.value(from: percentage)
     }
 

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Grabber.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Grabber.swift
@@ -1,0 +1,88 @@
+//
+//  ColorSlider+Grabber.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 13/04/24.
+//
+
+import Foundation
+import SwiftUI
+
+extension ColorSlider {
+  /// A view that displays the component the user grabs to pick values in the slider.
+  struct Grabber: View {
+
+    // MARK: - Stored Properties
+
+    /// The position of the grabber in the frame.
+    @State private var position: CGPoint
+
+    /// The frame that contains the grabber.
+    private let frame: CGRect
+
+    /// The range of values allowed in the slider.
+    private let range: ClosedRange<Value>
+
+    // MARK: - Computed Properties
+
+    /// The value of the slider.
+    @Binding var value: Value
+
+    @Environment(\.colorSliderGrabberStyle) var grabberStyle
+
+    /// The percentage of the value in the range.
+    private var percentage: CGFloat {
+      value.percentage(in: range)
+    }
+
+    // MARK: - Init
+
+    init(in frame: CGRect, value: Binding<Value>, range: ClosedRange<Value>) {
+      let radius = frame.height / 2
+      let trackFrame = frame.insetBy(dx: radius, dy: .zero)
+      
+      self.frame = trackFrame
+      self._value = value
+      self.range = range
+      self.position = Self.position(in: trackFrame, for: value.wrappedValue.percentage(in: range))
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+      Circle()
+        .fill(grabberStyle)
+        .stroke(.thinMaterial, lineWidth: 4)
+        .position(position)
+        .gesture(
+          DragGesture()
+            .onChanged { gesture in
+              updateValue(for: gesture.location)
+            }
+        )
+        .onChange(of: value) { oldValue, newValue in
+          position = Self.position(in: frame, for: percentage)
+        }
+    }
+
+    // MARK: - Functions
+
+    /// Updates the selected value from the coordinates of the grabber.
+    /// - Parameter location: The location of the drag gesture used to position the grabber.
+    func updateValue(for location: CGPoint) {
+      let percentage = location.x / frame.width
+      value = range.value(from: percentage)
+    }
+
+    /// Computes the position of the grabber.
+    /// - Parameters:
+    ///   - frame: The frame that contains the grabber.
+    ///   - percentage: The percentage of the selected value, used to correctly position the grabber.
+    static func position(in frame: CGRect, for percentage: Double) -> CGPoint {
+      CGPoint(
+        x: frame.minX + frame.width * percentage,
+        y: frame.midY
+      )
+    }
+  }
+}

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Style.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Style.swift
@@ -1,0 +1,30 @@
+//
+//  ColorSlider+Modifiers.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 12/04/24.
+//
+
+import Foundation
+import SwiftUI
+
+enum ColorSliderGrabberStyle: EnvironmentKey {
+  static var defaultValue: AnyShapeStyle = AnyShapeStyle(Color.blue)
+}
+
+extension EnvironmentValues {
+  var colorSliderGrabberStyle: AnyShapeStyle {
+    get {
+      self[ColorSliderGrabberStyle.self]
+    }
+    set {
+      self[ColorSliderGrabberStyle.self] = newValue
+    }
+  }
+}
+
+extension View {
+  func colorSliderGrabberStyle(_ style: some ShapeStyle) -> some View {
+    environment(\.colorSliderGrabberStyle, AnyShapeStyle(style))
+  }
+}

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Style.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Style.swift
@@ -8,11 +8,28 @@
 import Foundation
 import SwiftUI
 
+/// The `EnvironmentKey` to set the shape style of the ``ColorSider`` track.
+fileprivate enum ColorSliderTrackStyle: EnvironmentKey {
+  static var defaultValue: AnyShapeStyle = AnyShapeStyle(.background)
+}
+
+/// The `EnvironmentKey` to set the shape style of the ``ColorSider`` grabber.
 fileprivate enum ColorSliderGrabberStyle: EnvironmentKey {
   static var defaultValue: AnyShapeStyle = AnyShapeStyle(Color.blue)
 }
 
 extension EnvironmentValues {
+  /// The shape style of the ``ColorSlider`` track.
+  var colorSliderTrackStyle: AnyShapeStyle {
+    get {
+      self[ColorSliderTrackStyle.self]
+    }
+    set {
+      self[ColorSliderTrackStyle.self] = newValue
+    }
+  }
+
+  /// The shape style of the ``ColorSlider`` grabber.
   var colorSliderGrabberStyle: AnyShapeStyle {
     get {
       self[ColorSliderGrabberStyle.self]
@@ -24,6 +41,14 @@ extension EnvironmentValues {
 }
 
 extension View {
+  /// Sets the `ShapeStyle` for the ``ColorSlider`` track.
+  /// - Parameter style: The style of the track.
+  func colorSliderTrackStyle(_ style: some ShapeStyle) -> some View {
+    environment(\.colorSliderTrackStyle, AnyShapeStyle(style))
+  }
+
+  /// Sets the `ShapeStyle` for the ``ColorSlider`` grabber.
+  /// - Parameter style: The style of the grabber.
   func colorSliderGrabberStyle(_ style: some ShapeStyle) -> some View {
     environment(\.colorSliderGrabberStyle, AnyShapeStyle(style))
   }

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Style.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Style.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-enum ColorSliderGrabberStyle: EnvironmentKey {
+fileprivate enum ColorSliderGrabberStyle: EnvironmentKey {
   static var defaultValue: AnyShapeStyle = AnyShapeStyle(Color.blue)
 }
 

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Track.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Track.swift
@@ -12,11 +12,6 @@ extension ColorSlider {
   /// A view that displays the track of the slider.
   struct Track: View {
 
-    // MARK: - Constants
-
-    /// The height of the slider.
-    private let height: CGFloat = 48
-
     // MARK: - Stored Properties
 
     /// The frame of the view.
@@ -32,7 +27,7 @@ extension ColorSlider {
       RoundedRectangle(cornerRadius: 24, style: .continuous)
         .fill(style)
         .stroke(.thinMaterial, lineWidth: 2)
-        .frame(width: frame.width, height: height)
+        .frame(width: frame.width)
     }
   }
 }

--- a/ColorWheel/UI/ColorSlider/ColorSlider+Track.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider+Track.swift
@@ -1,0 +1,38 @@
+//
+//  ColorSlider+Track.swift
+//  ColorWheel
+//
+//  Created by Gaetano Matonti on 13/04/24.
+//
+
+import Foundation
+import SwiftUI
+
+extension ColorSlider {
+  /// A view that displays the track of the slider.
+  struct Track: View {
+
+    // MARK: - Constants
+
+    /// The height of the slider.
+    private let height: CGFloat = 48
+
+    // MARK: - Stored Properties
+
+    /// The frame of the view.
+    let frame: CGRect
+
+    // MARK: - Computed Properties
+
+    @Environment(\.colorSliderTrackStyle) var style
+
+    // MARK: - Body
+
+    var body: some View {
+      RoundedRectangle(cornerRadius: 24, style: .continuous)
+        .fill(style)
+        .stroke(.thinMaterial, lineWidth: 2)
+        .frame(width: frame.width, height: height)
+    }
+  }
+}

--- a/ColorWheel/UI/ColorSlider/ColorSlider.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider.swift
@@ -8,12 +8,8 @@
 import SwiftUI
 import Vectors
 
+/// A slider component to select values in a closed range.
 struct ColorSlider<Value>: View where Value: PercentageConvertible {
-
-  // MARK: - Constants
-
-  /// The height of the slider.
-  private let height: CGFloat = 48
 
   // MARK: - Stored Properties
 
@@ -22,20 +18,6 @@ struct ColorSlider<Value>: View where Value: PercentageConvertible {
 
   /// The value of the slider.
   @Binding var value: Value
-
-  // MARK: - Computed Properties
-
-  @Environment(\.backgroundStyle) var backgroundStyle
-
-  /// The shape of the slider track.
-  private var shape: some Shape {
-    RoundedRectangle(cornerRadius: 24, style: .continuous)
-  }
-
-  /// The radius of the grabber.
-  private var grabberRadius: CGFloat {
-    height / 2
-  }
 
   // MARK: - Init
 
@@ -49,16 +31,13 @@ struct ColorSlider<Value>: View where Value: PercentageConvertible {
   var body: some View {
     GeometryReader { geometry in
       ZStack {
-        shape
-          .fill(backgroundStyle ?? AnyShapeStyle(.background))
-          .stroke(.thinMaterial, lineWidth: 2)
-          .frame(width: geometry.size.width)
-        
+        Track(frame: geometry.frame(in: .local))
+
         Grabber(in: geometry.frame(in: .local), value: $value, range: range)
       }
     }
     .frame(height: 48)
-  }  
+  }
 }
 
 // MARK: - Previews

--- a/ColorWheel/UI/ColorSlider/ColorSlider.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Vectors
 
-struct ColorSlider<Value>: View where Value: PercentageRepresentable {
+struct ColorSlider<Value>: View where Value: PercentageConvertible {
   private let height: CGFloat = 48
     
   /// The value of the slider.
@@ -25,14 +25,6 @@ struct ColorSlider<Value>: View where Value: PercentageRepresentable {
   
   private var grabberRadius: CGFloat {
     height / 2
-  }
-  
-  private var minimum: Value {
-    range.lowerBound
-  }
-
-  private var maximum: Value {
-    range.upperBound
   }
   
   private var percentage: CGFloat {
@@ -104,27 +96,6 @@ extension ColorSlider {
   }
 }
 
-enum ColorSliderGrabberStyle: EnvironmentKey {
-  static var defaultValue: AnyShapeStyle = AnyShapeStyle(Color.blue)
-}
-
-extension EnvironmentValues {
-  var colorSliderGrabberStyle: AnyShapeStyle {
-    get {
-      self[ColorSliderGrabberStyle.self]
-    }
-    set {
-      self[ColorSliderGrabberStyle.self] = newValue
-    }
-  }
-}
-
-extension View {
-  func colorSliderGrabberStyle(_ style: some ShapeStyle) -> some View {
-    environment(\.colorSliderGrabberStyle, AnyShapeStyle(style))
-  }
-}
-
 #if DEBUG
 #Preview {
   struct Wrapped: View {
@@ -140,41 +111,3 @@ extension View {
     .backgroundStyle(ShaderLibrary.hue(.boundingRect))
 }
 #endif
-
-protocol PercentageRepresentable: Comparable {
-  func percentage(in range: ClosedRange<Self>) -> Double
-
-  static func value(from percentage: Double, in range: ClosedRange<Self>) -> Self
-}
-
-extension PercentageRepresentable where Self: BinaryFloatingPoint {
-  func percentage(in range: ClosedRange<Self>) -> Double {
-    Double((self - range.lowerBound) / (range.upperBound - range.lowerBound))
-  }
-
-  static func value(from percentage: Double, in range: ClosedRange<Self>) -> Self {
-    max(range.lowerBound, min(Self(percentage) * range.upperBound, range.upperBound))
-  }
-}
-
-extension CGFloat: PercentageRepresentable {}
-
-extension Float: PercentageRepresentable {}
-extension Double: PercentageRepresentable {}
-
-extension Angle: PercentageRepresentable {
-  func percentage(in range: ClosedRange<Angle>) -> Double {
-    Double((self.degrees - range.lowerBound.degrees) / (range.upperBound.degrees - range.lowerBound.degrees))
-  }
-
-  static func value(from percentage: Double, in range: ClosedRange<Angle>) -> Angle {
-    let degrees = max(range.lowerBound.degrees, min(percentage * range.upperBound.degrees, range.upperBound.degrees))
-    return .degrees(degrees)
-  }
-}
-
-extension ClosedRange where Bound: PercentageRepresentable {
-  func value(from percentage: Double) -> Bound {
-    Bound.value(from: percentage, in: self)
-  }
-}

--- a/ColorWheel/UI/ColorSlider/ColorSlider.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider.swift
@@ -11,6 +11,11 @@ import Vectors
 /// A slider component to select values in a closed range.
 struct ColorSlider<Value>: View where Value: PercentageConvertible {
 
+  // MARK: - Constants
+
+  /// The height of the slider.
+  private let height: CGFloat = 48
+
   // MARK: - Stored Properties
 
   /// The range of values allowed in the slider.
@@ -36,7 +41,7 @@ struct ColorSlider<Value>: View where Value: PercentageConvertible {
         Grabber(in: geometry.frame(in: .local), value: $value, range: range)
       }
     }
-    .frame(height: 48)
+    .frame(height: height)
   }
 }
 

--- a/ColorWheel/UI/ColorSlider/ColorSlider.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider.swift
@@ -9,34 +9,42 @@ import SwiftUI
 import Vectors
 
 struct ColorSlider<Value>: View where Value: PercentageConvertible {
+
+  // MARK: - Constants
+
+  /// The height of the slider.
   private let height: CGFloat = 48
-    
+
+  // MARK: - Stored Properties
+
+  /// The range of values allowed in the slider.
+  let range: ClosedRange<Value>
+
   /// The value of the slider.
   @Binding var value: Value
-  
-  /// The position of the grabber.
-  @State private var position: CGPoint = .zero
-  
+
+  // MARK: - Computed Properties
+
   @Environment(\.backgroundStyle) var backgroundStyle
-    
+
+  /// The shape of the slider track.
   private var shape: some Shape {
     RoundedRectangle(cornerRadius: 24, style: .continuous)
   }
-  
+
+  /// The radius of the grabber.
   private var grabberRadius: CGFloat {
     height / 2
   }
-  
-  private var percentage: CGFloat {
-    value.percentage(in: range)
-  }
-  
-  let range: ClosedRange<Value>
-  
+
+  // MARK: - Init
+
   init(value: Binding<Value>, range: ClosedRange<Value> = 0...1) {
     self._value = value
     self.range = range
   }
+
+  // MARK: - Body
 
   var body: some View {
     GeometryReader { geometry in
@@ -46,55 +54,14 @@ struct ColorSlider<Value>: View where Value: PercentageConvertible {
           .stroke(.thinMaterial, lineWidth: 2)
           .frame(width: geometry.size.width)
         
-        Grabber()
-          .position(position)
-          .gesture(
-            DragGesture()
-              .onChanged { gesture in
-                updateValue(for: gesture.location, in: geometry.frame(in: .local))
-              }
-          )
-          .onChange(of: value) { oldValue, newValue in
-            position = grabberPosition(in: geometry.frame(in: .local))
-          }
-          .onAppear {
-            position = grabberPosition(in: geometry.frame(in: .local))
-          }
+        Grabber(in: geometry.frame(in: .local), value: $value, range: range)
       }
     }
     .frame(height: 48)
-  }
-  
-  func updateValue(for location: CGPoint, in rect: CGRect) {
-    let percentage = location.x / trackRect(in: rect).width
-    value = range.value(from: percentage)
-  }
-  
-  func trackRect(in rect: CGRect) -> CGRect {
-    rect.insetBy(dx: grabberRadius, dy: .zero)
-  }
-  
-  func grabberPosition(in rect: CGRect) -> CGPoint {
-    let trackRect = trackRect(in: rect)
-    
-    return CGPoint(
-      x: trackRect.minX + trackRect.width * percentage,
-      y: rect.midY
-    )
-  }
+  }  
 }
 
-extension ColorSlider {
-  struct Grabber: View {
-    @Environment(\.colorSliderGrabberStyle) var grabberStyle
-
-    var body: some View {
-      Circle()
-        .fill(grabberStyle)
-        .stroke(.thinMaterial, lineWidth: 4)
-    }
-  }
-}
+// MARK: - Previews
 
 #if DEBUG
 #Preview {

--- a/ColorWheel/UI/ColorSlider/ColorSlider.swift
+++ b/ColorWheel/UI/ColorSlider/ColorSlider.swift
@@ -35,10 +35,12 @@ struct ColorSlider<Value>: View where Value: PercentageConvertible {
 
   var body: some View {
     GeometryReader { geometry in
-      ZStack {
-        Track(frame: geometry.frame(in: .local))
+      let frame = geometry.frame(in: .local)
 
-        Grabber(in: geometry.frame(in: .local), value: $value, range: range)
+      ZStack {
+        Track(frame: frame)
+
+        Grabber(in: frame, value: $value, range: range)
       }
     }
     .frame(height: height)

--- a/ColorWheel/UI/ColorWheel.swift
+++ b/ColorWheel/UI/ColorWheel.swift
@@ -13,17 +13,17 @@ struct ColorWheel: View {
   // MARK: - Stored Properties
   
   /// The hue of the color.
-  @Binding var hue: Angle
-  
+  @Binding private var hue: Angle
+
   /// The saturation of the color.
-  @Binding var saturation: Double
-  
+  @Binding private var saturation: Double
+
   /// The brightness of the color.
-  @Binding var brightness: Double
-  
+  @Binding private var brightness: Double
+
   /// The selected color harmony scheme.
-  let scheme: Scheme
-  
+  private let scheme: Scheme
+
   /// The shader of the color wheel.
   private var shader: Shader {
     ShaderLibrary.colorWheel(.boundingRect, .float(brightness))
@@ -34,6 +34,15 @@ struct ColorWheel: View {
   /// The additional colors in the current harmony color scheme.
   private var colors: [HSB] {
     scheme.colors(from: hue, saturation: saturation, brightness: brightness)
+  }
+
+  // MARK: - Init
+
+  init(hue: Binding<Angle>, saturation: Binding<Double>, brightness: Binding<Double>, scheme: Scheme) {
+    self._hue = hue
+    self._saturation = saturation
+    self._brightness = brightness
+    self.scheme = scheme
   }
 
   // MARK: - Body

--- a/ColorWheel/UI/ColorWheel.swift
+++ b/ColorWheel/UI/ColorWheel.swift
@@ -9,23 +9,30 @@ import SwiftUI
 
 /// A view that displays a HSB (Hue-Saturation-Brightness) color wheel.
 struct ColorWheel: View {
-
+  
   // MARK: - Stored Properties
-
+  
   /// The hue of the color.
   @Binding var hue: Angle
-
+  
   /// The saturation of the color.
   @Binding var saturation: Double
-
+  
+  /// The brightness of the color.
+  @Binding var brightness: Double
+  
   /// The selected color harmony scheme.
   let scheme: Scheme
+  
+  private var shader: Shader {
+    ShaderLibrary.colorWheel(.boundingRect, .float(brightness))
+  }
 
   // MARK: - Computed Properties
 
   /// The additional colors in the current harmony color scheme.
   private var colors: [HSB] {
-    scheme.colors(from: hue, saturation: saturation)
+    scheme.colors(from: hue, saturation: saturation, brightness: brightness)
   }
 
   // MARK: - Body
@@ -37,6 +44,7 @@ struct ColorWheel: View {
       ControlPoint(
         hue: $hue,
         saturation: $saturation,
+        brightness: brightness,
         frame: frame
       )
 
@@ -58,14 +66,8 @@ struct ColorWheel: View {
 
   private var colorWheel: some View {
     Circle()
-      .fill(ShaderLibrary.colorWheel(.boundingRect))
+      .fill(shader)
       .stroke(.regularMaterial, lineWidth: 4)
-      .background {
-        Circle()
-          .fill(ShaderLibrary.colorWheel(.boundingRect))
-          .blur(radius: 60)
-          .opacity(0.4)
-      }
   }
 
   /// Computes the coordinates of the color in the polar coordinates of the passed rectangle.
@@ -83,7 +85,8 @@ struct ColorWheel: View {
 #Preview {
   ColorWheel(
     hue: .constant(.zero),
-    saturation: .constant(1),
+    saturation: .constant(1), 
+    brightness: .constant(1),
     scheme: .triad
   )
   .padding(48)

--- a/ColorWheel/UI/ColorWheel.swift
+++ b/ColorWheel/UI/ColorWheel.swift
@@ -24,6 +24,7 @@ struct ColorWheel: View {
   /// The selected color harmony scheme.
   let scheme: Scheme
   
+  /// The shader of the color wheel.
   private var shader: Shader {
     ShaderLibrary.colorWheel(.boundingRect, .float(brightness))
   }

--- a/ColorWheel/UI/ContentView.swift
+++ b/ColorWheel/UI/ContentView.swift
@@ -18,15 +18,26 @@ struct ContentView: View {
   /// The saturation of the main color.
   @State private var saturation: Double = 1.0
 
+  /// The brightness of the main color.
+  @State private var brightness: Double = 1.0
+
   /// The selected color harmony scheme.
   @State private var scheme: Scheme = .monochromatic
+  
+  private var hueProgress: Binding<Double> {
+    Binding {
+      hue.absolute.degrees / 360
+    } set: { newValue in
+      hue = .degrees(newValue * 360).absolute
+    }
+  }
 
   // MARK: - Computed Properties
 
   /// The colors selected by the harmony scheme.
   var colors: [HSB] {
-    var colors = scheme.colors(from: hue, saturation: saturation)
-    colors.append(HSB(id: 0, hue: hue, saturation: saturation, brightness: 1))
+    var colors = scheme.colors(from: hue, saturation: saturation, brightness: brightness)
+    colors.append(HSB(id: 0, hue: hue, saturation: saturation, brightness: brightness))
 
     return colors.sorted { $0.hue < $1.hue }
   }
@@ -37,8 +48,37 @@ struct ContentView: View {
     VStack(spacing: 48) {
       GradientPalette(colors: colors)
 
-      ColorWheel(hue: $hue, saturation: $saturation, scheme: scheme)
-
+      ColorWheel(
+        hue: $hue,
+        saturation: $saturation,
+        brightness: $brightness,
+        scheme: scheme
+      )
+      
+      ColorSlider(value: hueProgress)
+        .backgroundStyle(ShaderLibrary.hue(.boundingRect))
+        .colorSliderGrabberStyle(Color(hue: hue, saturation: 1, brightness: 1))
+      
+      ColorSlider(value: $saturation)
+        .backgroundStyle(
+          .linearGradient(
+            colors: [.white, Color(hue: hue, saturation: 1, brightness: 1)],
+            startPoint: .leading,
+            endPoint: .trailing
+          )
+        )
+        .colorSliderGrabberStyle(.white)
+      
+      ColorSlider(value: $brightness)
+        .backgroundStyle(
+          .linearGradient(
+            colors: [.black, Color(hue: hue, saturation: 1, brightness: 1)],
+            startPoint: .leading,
+            endPoint: .trailing
+          )
+        )
+        .colorSliderGrabberStyle(.white)
+      
       Picker("Color Scheme", selection: $scheme) {
         ForEach(Scheme.allCases, id: \.self) { scheme in
           Text(scheme.title)

--- a/ColorWheel/UI/ContentView.swift
+++ b/ColorWheel/UI/ContentView.swift
@@ -24,14 +24,6 @@ struct ContentView: View {
   /// The selected color harmony scheme.
   @State private var scheme: Scheme = .monochromatic
   
-  private var hueProgress: Binding<Double> {
-    Binding {
-      hue.absolute.degrees / 360
-    } set: { newValue in
-      hue = .degrees(newValue * 360).absolute
-    }
-  }
-
   // MARK: - Computed Properties
 
   /// The colors selected by the harmony scheme.
@@ -49,13 +41,13 @@ struct ContentView: View {
       GradientPalette(colors: colors)
 
       ColorWheel(
-        hue: $hue,
+        hue: $hue.absolute,
         saturation: $saturation,
         brightness: $brightness,
         scheme: scheme
       )
       
-      ColorSlider(value: hueProgress)
+      ColorSlider(value: $hue.absolute, range: .zero...Angle(degrees: 360))
         .backgroundStyle(ShaderLibrary.hue(.boundingRect))
         .colorSliderGrabberStyle(Color(hue: hue, saturation: 1, brightness: 1))
       

--- a/ColorWheel/UI/ContentView.swift
+++ b/ColorWheel/UI/ContentView.swift
@@ -48,11 +48,11 @@ struct ContentView: View {
       )
       
       ColorSlider(value: $hue.absolute, range: .zero...Angle(degrees: 360))
-        .backgroundStyle(ShaderLibrary.hue(.boundingRect))
+        .colorSliderTrackStyle(ShaderLibrary.hue(.boundingRect))
         .colorSliderGrabberStyle(Color(hue: hue, saturation: 1, brightness: 1))
       
       ColorSlider(value: $saturation)
-        .backgroundStyle(
+        .colorSliderTrackStyle(
           .linearGradient(
             colors: [.white, Color(hue: hue, saturation: 1, brightness: 1)],
             startPoint: .leading,
@@ -62,7 +62,7 @@ struct ContentView: View {
         .colorSliderGrabberStyle(.white)
       
       ColorSlider(value: $brightness)
-        .backgroundStyle(
+        .colorSliderTrackStyle(
           .linearGradient(
             colors: [.black, Color(hue: hue, saturation: 1, brightness: 1)],
             startPoint: .leading,

--- a/ColorWheel/UI/ControlPoint.swift
+++ b/ColorWheel/UI/ControlPoint.swift
@@ -14,6 +14,9 @@ struct ControlPoint: View {
 
   // MARK: - Stored Properties
 
+  /// The current position of the control point.
+  @State private var position: CGPoint
+
   /// The hue of the currently selected color.
   @Binding private var hue: Angle
 
@@ -21,10 +24,7 @@ struct ControlPoint: View {
   @Binding private var saturation: Double
 
   /// The brightness of the currently selected color.
-  private var brightness: Double
-
-  /// The current position of the control point.
-  @State private var position: CGPoint
+  private let brightness: Double
 
   /// The frame of the circle.
   private let frame: CGRect
@@ -54,11 +54,7 @@ struct ControlPoint: View {
     self.brightness = brightness
     self.frame = frame
 
-    self.position = CGPoint(
-      angle: hue.wrappedValue,
-      radius: saturation.wrappedValue * frame.width / 2,
-      center: frame.center
-    )
+    self.position = Self.position(from: hue.wrappedValue, saturation: saturation.wrappedValue, in: frame)
   }
 
   // MARK: - Body
@@ -83,25 +79,44 @@ struct ControlPoint: View {
 
   // MARK: Functions
 
-  /// Updates the color from the coordinates of the control point.
+  /// Updates the values of the color from the coordinates of the control point.
+  /// - Parameter location: The location of the drag gesture used to compute the new position of the control point.
   private func updateColor(from location: CGPoint) {
+    /// The vector of the control point relative to the center of the wheel.
     let position = (location - center).limit(radius)
+
     updateHue(from: position)
     updateSaturation(from: position)
   }
 
   /// Updates the hue of the color from the angle of the control point.
+  /// - Parameter position: The coordinates of the control point in the frame.
   private func updateHue(from position: CGPoint) {
     hue = position.normalized.heading
   }
 
   /// Updates the saturation of the color from the distance of the control point to the center.
+  /// - Parameter position: The coordinates of the control point in the frame.
   private func updateSaturation(from position: CGPoint) {
     saturation = position.magnitude / radius
   }
   
+  /// Updates the position of the control point from the values of the color.
+  /// - Parameters:
+  ///   - hue: The angle of the color hue.
+  ///   - saturation: The value of the saturation.
   private func updatePosition(from hue: Angle, saturation: CGFloat) {
-    position = CGPoint(
+    position = Self.position(from: hue, saturation: saturation, in: frame)
+  }
+
+  /// Computes the position of the control point from the values of the color.
+  /// - Parameters:
+  ///   - hue: The angle of the color hue.
+  ///   - saturation: The value of the saturation.
+  ///   - frame: The frame that contains the control point.
+  /// - Returns: The coordinates of the control point.
+  private static func position(from hue: Angle, saturation: CGFloat, in frame: CGRect) -> CGPoint {
+    CGPoint(
       angle: hue,
       radius: saturation * frame.width / 2,
       center: frame.center


### PR DESCRIPTION
### Description
This PR adds sliders to individually control the hue, saturation, and brightness parameters.

### Changes
- Modified the `colorWheel` shader to change appearance based on brightness.
- Added `PercentageConvertible` protocol to convert conforming types to percentages and back.
- Added the `ColorSlider` to select values in a closed range of values of `PercentageConvertible` types.
- Added support for parametric brightness.
- Modified the `ControlPoint` implementation to support updating the position from hue and saturation values.

### To do
- [x] Fix interaction with the sliders causing an abrupt change of value when drag begins.

### Screenshots
https://github.com/gaetanomatonti/swift-color-wheel/assets/19956801/754f864e-9149-4111-b329-db21f310a0dc

